### PR TITLE
fix: generate Prisma client before running tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,5 +19,6 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter ./backend prisma generate
       - run: pnpm lint
       - run: pnpm test


### PR DESCRIPTION
This pull request makes a small adjustment to the CI workflow configuration. The change ensures that Prisma client code is generated for the backend before running linting and tests.

* Added a step to run `pnpm --filter ./backend prisma generate` in the `.github/workflows/ci.yml` file to generate Prisma client code for the backend during the CI process.- Add 'pnpm --filter ./backend prisma generate' step to CI workflow
- Ensures @prisma/client is initialized before tests run
- Resolves 'Prisma client did not initialize yet' error in CI

## Summary

<!-- Briefly explain the changes in this PR. -->

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] Manual verification (describe)

## Checklist

- [ ] Docs updated (README/MDX/API schema)
- [ ] Tests added or updated
- [ ] Screenshots for UI changes
- [ ] Linked issue: #

## Notes

<!-- Anything reviewers should pay extra attention to. -->
