### PR TITLE
feat: enable blank issues in GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: eightblock Discussions
     url: https://github.com/eightblock-dev/eightblock/discussions


### PR DESCRIPTION
This pull request makes a minor configuration change to the GitHub issue template settings. Blank issues are now enabled, allowing users to open issues without using a predefined template.

* Enabled blank issues by setting `blank_issues_enabled` to `true` in `.github/ISSUE_TEMPLATE/config.yml`.- Change blank_issues_enabled from false to true
- Allows users to create custom issues without using templates
- Provides flexibility for unique bug reports and feature requests

## Summary

<!-- Briefly explain the changes in this PR. -->

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] Manual verification (describe)

## Checklist

- [ ] Docs updated (README/MDX/API schema)
- [ ] Tests added or updated
- [ ] Screenshots for UI changes
- [ ] Linked issue: #

## Notes

<!-- Anything reviewers should pay extra attention to. -->
