### PR TITLE
fix: use correct command to generate Prisma client in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter ./backend prisma generate
+      - name: Generate Prisma Client
+        run: cd backend && pnpm prisma generate
       - run: pnpm lint
       - run: pnpm test


### PR DESCRIPTION
This pull request makes a minor update to the CI workflow to clarify the Prisma client generation step. The change improves readability and maintainability by using a named step and a more explicit command.

* Changed the Prisma client generation step in `.github/workflows/ci.yml` to use a named step and an explicit directory change for better clarity.- Change from 'pnpm --filter ./backend prisma generate' to 'cd backend && pnpm prisma generate'
- The filter syntax doesn't work for prisma commands in CI
- Add descriptive name to the generation step for better CI logs
- Resolves '@prisma/client did not initialize yet' error in tests

## Summary

<!-- Briefly explain the changes in this PR. -->

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] Manual verification (describe)

## Checklist

- [ ] Docs updated (README/MDX/API schema)
- [ ] Tests added or updated
- [ ] Screenshots for UI changes
- [ ] Linked issue: #

## Notes

<!-- Anything reviewers should pay extra attention to. -->
