### PR TITLE
fix(deploy): use git reset --hard to discard VPS local changes before…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
             echo "📥 Pulling latest code..."
             git fetch origin
             git checkout main
-            git pull origin main
+            git reset --hard origin/main
 
             # Backend updates
             echo "🔧 Updating backend..."


### PR DESCRIPTION
This pull request makes a minor update to the deployment workflow. The change replaces the `git pull origin main` command with `git reset --hard origin/main` to ensure the local `main` branch is exactly in sync with the remote, discarding any local changes.
