### PR TITLE
fix(routes): move /:slug/related before /:slug to prevent route shado…

### DIFF
--- a/backend/src/routes/article-routes.ts
+++ b/backend/src/routes/article-routes.ts
@@ -26,8 +26,8 @@ const articleSchema = z.object({
 
 router.get('/', listArticles);
 router.get('/wallet/:walletAddress', getArticlesByWallet);
-router.get('/:slug', getArticle);
 router.get('/:slug/related', getRelatedArticles);
+router.get('/:slug', getArticle);
 router.post('/', requireAuth, validateBody(articleSchema), createArticle);
 router.put('/:id', requireAuth, validateBody(articleSchema.partial()), updateArticle);
 router.delete('/:id', requireAuth, deleteArticle);


### PR DESCRIPTION
This pull request makes a minor change to the routing order in `backend/src/routes/article-routes.ts` to ensure correct route matching. The `/:slug` route is moved below the more specific `/:slug/related` route to prevent route conflicts.

- Routing improvements:
  * Moved the `/:slug` route below `/:slug/related` in `article-routes.ts` to ensure that requests to `/related` are correctly matched before the generic slug route.
