### PR TITLE
fix(deploy): compile backend TS before restart; run dist/server.js in…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,9 +38,10 @@ jobs:
             # Backend updates
             echo "🔧 Updating backend..."
             cd backend
-            pnpm install --prod
+            pnpm install
             npx prisma generate
             npx prisma db push
+            pnpm build
 
             # Frontend updates
             echo "🎨 Building frontend..."

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -3,8 +3,8 @@ module.exports = {
     {
       name: 'eightblock-backend',
       cwd: '/var/www/eightblock/backend',
-      script: 'tsx',
-      args: 'src/server.ts',
+      script: 'node',
+      args: 'dist/server.js',
       instances: 2,
       exec_mode: 'cluster',
       env: {


### PR DESCRIPTION
This pull request updates the deployment workflow and process for the backend service, focusing on ensuring the backend is built before deployment and updating the process manager configuration to run the built JavaScript files instead of TypeScript source files.

**Deployment workflow improvements:**

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L41-R44): Added a `pnpm build` step after installing dependencies to ensure the backend is built before deployment. Also changed `pnpm install --prod` to `pnpm install` to install all dependencies, not just production ones.

**Process manager configuration:**

* [`ecosystem.config.js`](diffhunk://#diff-b559cd20e65343dbc9f1669a6a87154173267be8a8c172498f46d0e5b4c458d2L6-R7): Updated the backend process to run `node dist/server.js` instead of using `tsx src/server.ts`, reflecting the switch to running built JavaScript files rather than TypeScript source files.
